### PR TITLE
Change user-home redirects to profile

### DIFF
--- a/openCurrents/static/css/app.css
+++ b/openCurrents/static/css/app.css
@@ -1445,6 +1445,9 @@ input[type="checkbox"] + label.vol-arrived {
 
 /* time-tracker */
 
+#user-orgs {
+  margin-bottom: 2rem;
+}
 
 /* approve-hours */
 

--- a/openCurrents/templates/check-email.html
+++ b/openCurrents/templates/check-email.html
@@ -18,15 +18,17 @@
         {% endif %}
         
         <div class="row">
-          <h3 class="title-sub">Check your email</h3>
-          <p class="two-margin-bottom">To confirm your account, click the link in the email that we just sent to {{ user_email }}.</p>
+          <div class="medium-8 small-centered columns">
+            <h3 class="title-sub">Check your email</h3>
+            <p class="three-halves-margin-bottom">To confirm your account, click the link in the email that we just sent to {{ user_email }}.</p>
+          </div>
         </div>
 
           <form method="post" action="{% url 'openCurrents:process_resend' user_email %}">
                   {% csrf_token %}
 
                   <div class="row center half-margin-top">
-                    <input type="submit" class="resend-email_open button large round" value="Resend email"/>
+                    <input type="submit" class="resend-email_open button round" value="Resend email"/>
                   </div>
           </form>
 

--- a/openCurrents/templates/live-dashboard.html
+++ b/openCurrents/templates/live-dashboard.html
@@ -23,8 +23,10 @@
         {% endif %}
 
         <div class="row">
+          <div class="small-12 medium-8 small-centered columns">
             <h4 class="title-sub">Let's {{ event.project.name }}!</h4>
-            <p> {{ event.project.org.name }} </p>
+            <p>with {{ event.project.org.name }}</p>
+          </div>
         </div>
 
         <form id='form-add' method="post">

--- a/openCurrents/templates/profile.html
+++ b/openCurrents/templates/profile.html
@@ -153,7 +153,7 @@
           <p>If you'd like to help us fulfill our mission even sooner, please don't hesitate to reach out!</p>
 
           <p class="three-halves-margin-top">
-            <a href="" class="button round small">Get in touch</a>
+            <a href="javascript:void(Tawk_API.toggle())" class="button round small">Get in touch</a>
             <a class="welcome-popup_close button round secondary small">Close</a>
           </p>
         </div>

--- a/openCurrents/templates/time-tracker.html
+++ b/openCurrents/templates/time-tracker.html
@@ -25,7 +25,7 @@
 
               <h6 class="subtitle">for</h6>
               
-              <select id="user-orgs" class="two-margin-bottom">
+              <select id="user-orgs">
                 <option disabled selected hidden>Select organization</option>
                 <!-- all requested orgs should appear here unless org declines a volunteer -->
                 <option>Bike Austin</option>

--- a/openCurrents/templates/time-tracker.html
+++ b/openCurrents/templates/time-tracker.html
@@ -37,7 +37,7 @@
                 
               </select>
               
-              <a href="{% url 'openCurrents:org-signup' %}" class="add-org-popup_open button round secondary" tabindex=0>Nominate an organization</a>
+              <a href="{% url 'openCurrents:org-signup' %}" class="button round secondary" tabindex=0>Nominate an organization</a>
           </div>
         </div>
 

--- a/openCurrents/views.py
+++ b/openCurrents/views.py
@@ -877,7 +877,7 @@ def process_email_confirmation(request, user_email):
 
         if user.has_usable_password():
             logger.warning('user %s has already been verified', user_email)
-            return redirect('openCurrents:user-home')
+            return redirect('openCurrents:profile')
 
         # second, make sure the verification token and user email match
         token_record = None
@@ -897,7 +897,7 @@ def process_email_confirmation(request, user_email):
 
         if token_record.is_verified:
             logger.warning('token for %s has already been verified', user_email)
-            return redirect('openCurrents:user-home')
+            return redirect('openCurrents:profile')
 
         # mark the verification record as verified
         token_record.is_verified = True
@@ -969,7 +969,7 @@ def process_email_confirmation(request, user_email):
 
         except:
             logger.info('No org association')
-            return redirect('openCurrents:user-home')
+            return redirect('openCurrents:profile')
 
     #if form was invalid for bad password, still need to preserve token 
     else:
@@ -1047,7 +1047,7 @@ def process_org_signup(request):
             request.user.email
         )
         return redirect(
-            'openCurrents:user-home',
+            'openCurrents:profile',
             status_msg='Thank you for nominating %s to openCurrents!' % org.name
         )
 


### PR DESCRIPTION
Somehow the form for confirm-account and other views were redirecting to user-home, which we're not using anymore.

Also fixed 'get in touch' button (#148). However I'd like for the 'Welcome' popup to only display the first time they log in. Created issue #158 to address this