### PR TITLE
Org signup msg

### DIFF
--- a/openCurrents/views.py
+++ b/openCurrents/views.py
@@ -1989,7 +1989,7 @@ def process_org_signup(request):
         )
         return redirect(
             'openCurrents:profile',
-            status_msg='Thank you for nominating %s to openCurrents!' % org.name
+            status_msg='Thank you for registering %s with openCurrents!' % org.name
         )
 
     else:


### PR DESCRIPTION
Changing org signup success message to say Thank you for registering the org instead of Thank you for nominating since the org creation is automatic.