### PR TITLE
Display coordinator name on event-detail, designed without working variables; add coordinator dropdown on create-event

### DIFF
--- a/openCurrents/forms.py
+++ b/openCurrents/forms.py
@@ -314,8 +314,7 @@ class ProjectCreateForm(forms.Form):
 class EventRegisterForm(forms.Form):
     contact_message = forms.CharField(
         required=False,
-        label='Contact event coordinator (optional)',
-        help_text='Ask a question, confirm your attendance, or just say hello',
+        label='Get in touch (optional)',
         widget=forms.Textarea(attrs={
             'rows': '3'
         }),

--- a/openCurrents/templates/event-detail.html
+++ b/openCurrents/templates/event-detail.html
@@ -51,18 +51,17 @@
                   <h6 class="navy inline">Contact invited volunteers</h6>
                   <a class="registrants-box_open no-wrap">See invitees</a>
                 {% elif is_registered %}
-                  <h6 class="navy inline">Contact event coordinator</h6>
+                  <h6 class="navy inline">Get in touch</h6>
                 {% else %}
                   <h6 class="navy inline">{{ form.contact_message.label }}</h6>
                 {% endif %}
               
-              {% if form.contact_message.help_text %}
                 <p class="small-text grey no-margin-bottom">
                   {% if not coordinator %}
-                    {{ form.contact_message.help_text|safe }}
+                    Event coordinator: {{ coordinator.firstname }} {{ coordinator.lastname }}
                   {% endif %}
                 </p>
-              {% endif %}
+
               {{ form.contact_message }}
 
             </div>

--- a/openCurrents/templates/org-admin.html
+++ b/openCurrents/templates/org-admin.html
@@ -70,7 +70,7 @@
             <h6 class="one-margin-top no-margin-bottom">Org hours tracked: {{ issued_by_all }}</h6>
             <h6 class="half-margin-bottom">My hours tracked: {{ issued_by_admin }}</h6>
 
-              <a {% if user_time_log_status %} href="{% url 'openCurrents:approve-hours' %}" class="button round tiny"{% else %} href="javascript:status()" class="button round tiny secondary"{% endif %}">Approve hours</a>
+              <a {% if user_time_log_status %} href="{% url 'openCurrents:approve-hours' %}" class="button round tiny"{% else %} href="javascript:status()" class="button round tiny secondary"{% endif %}>Approve hours</a>
           </div>
         </div>
 
@@ -90,7 +90,7 @@
                 My hours tracked: {{ issued_by_admin }}
               </h6>              
               <a href="{% url 'openCurrents:create-event' orgid %}" {% if user_time_log_status %} class="button secondary tiny round" {% else %} class="button tiny round" {% endif %}>Create event</a>
-              <a {% if user_time_log_status %} href="{% url 'openCurrents:approve-hours' %}" class="button round tiny"{% else %} href="javascript:status()" class="button round tiny secondary"{% endif %}">Approve hours</a>
+              <a {% if user_time_log_status %} href="{% url 'openCurrents:approve-hours' %}" class="button round tiny"{% else %} href="javascript:status()" class="button round tiny secondary"{% endif %}>Approve hours</a>
             </div>
           </div>
         </div>
@@ -140,6 +140,9 @@
                     <a class="mini-open"><i class="blue half-margin-right fa-chevron-circle-down fa fa-lg"></i></a>
                     <ul class="mini-menu">
                       <a href="{% url 'openCurrents:event-detail' event.id %}"><li>View event details</li></a>
+                      {# {% if user is coordinator %} #}
+                      <a href="{% url 'openCurrents:event-detail' event.id %}"><li>View & contact invitees</li></a>
+                      {# {% endif %} #}
                       <a href="{% url 'openCurrents:invite-volunteers' event.id %}"><li>Invite volunteers</li></a>
                       <!-- <a href="{% url 'openCurrents:edit-event' event.id %}"><li>Edit event</li></a> -->
                       <a href="{% url 'openCurrents:live-dashboard' event.id %}"><li>Preview live check-in</li></a>


### PR DESCRIPTION
@nickolashe you mentioned that you wanted to take care of removing coordinator_email and coordinator_firstname (https://opencurrents.slack.com/archives/D3VLYUDFZ/p1508801272000010) so those still show up in models and views. They also show up in edit-event but that will change when `edit_event_form` branch is merged.