### PR TITLE
Add facebook pixel with advanced tracking

### DIFF
--- a/openCurrents/templates/check-email.html
+++ b/openCurrents/templates/check-email.html
@@ -1,13 +1,6 @@
 {% extends "layouts/base.html" %}
 {% load staticfiles %}
 
-{% block head %}
-  <!-- Facebook Pixel -->
-  <script>
-    fbq('track', 'CompleteRegistration');
-  </script>
-{% endblock head %}
-
 {% block status %}
   {% if status == "success" %}
     <div class="success row one-margin-top">
@@ -23,6 +16,11 @@
 {% endblock status %}
 
 {% block heading %}
+  <!-- Facebook Pixel -->
+  <script>
+    fbq('track', 'CompleteRegistration');
+  </script>
+
   <div class="row">
     <div class="medium-8 small-centered columns">
       <h3 class="title">

--- a/openCurrents/templates/check-email.html
+++ b/openCurrents/templates/check-email.html
@@ -1,6 +1,13 @@
 {% extends "layouts/base.html" %}
 {% load staticfiles %}
 
+{% block head %}
+  <!-- Facebook Pixel -->
+  <script>
+    fbq('track', 'CompleteRegistration');
+  </script>
+{% endblock head %}
+
 {% block status %}
   {% if status == "success" %}
     <div class="success row one-margin-top">
@@ -14,7 +21,7 @@
     </div>
   {% endif %}
 {% endblock status %}
-        
+
 {% block heading %}
   <div class="row">
     <div class="medium-8 small-centered columns">
@@ -26,7 +33,7 @@
     </div>
   </div>
 {% endblock heading %}
-        
+
 {% block content %}
   <form method="post" action="{% url 'openCurrents:process_resend_verification' user_email %}">
     {% csrf_token %}
@@ -35,7 +42,7 @@
     </div>
   </form>
 {% endblock content %}
-        
+
 
 {% block popups %}
   <div id="change-email-popup" class="modal center small-12 medium-9 large-7 small-centered columns">
@@ -59,7 +66,7 @@
     </div>
   </div>
 {% endblock popups %}
-  
+
 {% block js %}
   <script type="text/javascript">
     $(document).ready(function(){

--- a/openCurrents/templates/partials/head.html
+++ b/openCurrents/templates/partials/head.html
@@ -32,7 +32,11 @@
   t.src=v;s=b.getElementsByTagName(e)[0];
   s.parentNode.insertBefore(t,s)}(window, document,'script',
   'https://connect.facebook.net/en_US/fbevents.js');
-  fbq('init', '146875852629962');
+  fbq('init', '146875852629962', {
+    em: user_email,
+    fn: user_firstname,
+    ln: user_lastname,
+  });
   fbq('track', 'PageView');
 </script>
 <noscript><img height="1" width="1" style="display:none"


### PR DESCRIPTION
@nickolashe I took a best guess as to what variables to add to Facebook Pixel to track our signup form. I used the `name=` field from HTML. Does that seem right? Here are FB's instructions:

<img width="630" alt="screen shot 2018-01-04 at 2 53 11 pm" src="https://user-images.githubusercontent.com/3347095/34583875-0a6484fa-f15f-11e7-95e6-7d37d5e8765c.png">